### PR TITLE
Hides news feed on new Facebook redesign

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,18 +1,7 @@
-#topnews_main_stream_408239535924329
-{
-    height: 0;
-    width: 0;
-    overflow: hidden;
-}
-
-#pagelet_ego_pane
-{
-    height: 0;
-    width: 0;
-    overflow: hidden;
-}
-
-#m_newsfeed_stream
+#topnews_main_stream_408239535924329,
+#pagelet_ego_pane,
+#m_newsfeed_stream,
+div[role="feed"]
 {
   height: 0;
   width: 0;


### PR DESCRIPTION
The new Facebook redesign started rolling out at the beginning of January this year.